### PR TITLE
Add reference to the python wrapper and introduce tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,18 @@ If you want to change input data file, please
 * edit `./examples/main.c` with the proper file path,
 * change `nb_lines` and `nb_cols` in accordance with you data.
 
+### Use the Python wrapper
+
+We created a python wrapper of the present implementation. It brings :
+
+* The benefit of Python flexibility in terms of formating input data, 
+* The benefit of C speed implementation. 
+
+You can find the Python wrapper here : [https://github.com/oboulant/tamis](https://github.com/oboulant/tamis). 
+
 ## Tests
+
+We implemented unit tests using [Infer](https://fbinfer.com/docs/getting-started/). You can compile and run those tests using the following instructions. 
 
 ### Clean and Compile
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It brings :
 
 ## Tests
 
-We implemented unit tests using [Infer](https://fbinfer.com/docs/getting-started/). You can compile and run those tests using the following instructions. 
+We implemented unit tests using [Unity](https://github.com/ThrowTheSwitch/Unity). You can compile and run those tests using the following instructions. 
 
 ### Clean and Compile
 
@@ -60,3 +60,6 @@ We implemented unit tests using [Infer](https://fbinfer.com/docs/getting-started
 > ./test
 ```
 
+### Infer
+
+We also made a run local runs (not integrated within the CI) [Infer](https://fbinfer.com/docs/getting-started/) in order to check that there was no memory management errors. 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ If you want to change input data file, please
 * edit `./examples/main.c` with the proper file path,
 * change `nb_lines` and `nb_cols` in accordance with you data.
 
-### Use the Python wrapper
+## Run on your own data : Use the Python wrapper
 
-We created a python wrapper of the present implementation. It brings :
+If you want to use the present implementation on your own data, the easiest way is to use our Python wrapper. It can be found here : [https://github.com/oboulant/tamis](https://github.com/oboulant/tamis). 
+It brings :
 
 * The benefit of Python flexibility in terms of formating input data, 
 * The benefit of C speed implementation. 
-
-You can find the Python wrapper here : [https://github.com/oboulant/tamis](https://github.com/oboulant/tamis). 
 
 ## Tests
 


### PR DESCRIPTION
- [x] Add a reference to the Python wrapper [tamis](https://github.com/oboulant/tamis) in the `Examples` section so that users know there is an easiest way to test on their own data rather than editing C source code provided as example. 
- [x] Mention [Infer](https://fbinfer.com/docs/getting-started/)
